### PR TITLE
kafka: Connection error handling

### DIFF
--- a/src/kafka/connection/kafka_connection.cc
+++ b/src/kafka/connection/kafka_connection.cc
@@ -27,8 +27,8 @@ namespace seastar {
 namespace kafka {
 
 future<lw_shared_ptr<kafka_connection>> kafka_connection::connect(const std::string& host, uint16_t port,
-        const std::string& client_id) {
-    return tcp_connection::connect(host, port)
+        const std::string& client_id, uint32_t timeout_ms) {
+    return tcp_connection::connect(host, port, timeout_ms)
     .then([client_id] (lw_shared_ptr<tcp_connection> connection) {
         return make_lw_shared<kafka_connection>(connection, client_id);
     }).then([] (lw_shared_ptr<kafka_connection> connection) {

--- a/src/kafka/connection/kafka_connection.hh
+++ b/src/kafka/connection/kafka_connection.hh
@@ -110,7 +110,7 @@ private:
 
 public:
     static future<lw_shared_ptr<kafka_connection>> connect(const std::string& host, uint16_t port,
-            const std::string& client_id);
+            const std::string& client_id, uint32_t timeout_ms);
 
     kafka_connection(lw_shared_ptr<tcp_connection> connection, std::string client_id) :
         _connection(std::move(connection)),

--- a/src/kafka/connection/tcp_connection.hh
+++ b/src/kafka/connection/tcp_connection.hh
@@ -31,6 +31,11 @@ namespace seastar {
 
 namespace kafka {
 
+struct tcp_connection_exception : public std::runtime_error {
+public:
+    tcp_connection_exception(const std::string& message) : runtime_error(message) {}
+};
+
 class tcp_connection {
 
     net::inet_address _host;

--- a/src/kafka/connection/tcp_connection.hh
+++ b/src/kafka/connection/tcp_connection.hh
@@ -35,17 +35,18 @@ class tcp_connection {
 
     net::inet_address _host;
     uint16_t _port;
+    uint32_t _timeout_ms;
     connected_socket _fd;
     input_stream<char> _read_buf;
     output_stream<char> _write_buf;
 
 public:
+    static future<lw_shared_ptr<tcp_connection>> connect(const std::string& host, uint16_t port, uint32_t timeout_ms);
 
-    static future<lw_shared_ptr<tcp_connection>> connect(const std::string& host, uint16_t port);
-
-    tcp_connection(const net::inet_address& host, uint16_t port, connected_socket&& fd) noexcept
+    tcp_connection(const net::inet_address& host, uint16_t port, uint32_t timeout_ms, connected_socket&& fd) noexcept
             : _host(host)
             , _port(port)
+            , _timeout_ms(timeout_ms)
             , _fd(std::move(fd))
             , _read_buf(_fd.input())
             , _write_buf(_fd.output()) {};

--- a/src/kafka/producer/kafka_producer.cc
+++ b/src/kafka/producer/kafka_producer.cc
@@ -47,7 +47,7 @@ namespace kafka {
 kafka_producer::kafka_producer(std::string client_id) : _client_id(std::move(client_id)) {}
 
 seastar::future<> kafka_producer::init(std::string server_address, uint16_t port) {
-    auto connection_future = kafka_connection::connect(server_address, port, _client_id).then([this] (auto connection) {
+    auto connection_future = kafka_connection::connect(server_address, port, _client_id, 500).then([this] (auto connection) {
         _connection = connection;
     });
 

--- a/src/kafka/protocol/metadata_response.hh
+++ b/src/kafka/protocol/metadata_response.hh
@@ -76,6 +76,7 @@ public:
     kafka_int32_t _controller_id;
     kafka_array_t<metadata_response_topic> _topics;
     kafka_int32_t _cluster_authorized_operations;
+    kafka_int16_t _error_code;
 
     void serialize(std::ostream &os, int16_t api_version) const;
 

--- a/src/kafka/protocol/produce_response.hh
+++ b/src/kafka/protocol/produce_response.hh
@@ -71,6 +71,7 @@ class produce_response {
 public:
     kafka_array_t<produce_response_topic_produce_response> _responses;
     kafka_int32_t _throttle_time_ms;
+    kafka_int16_t _error_code;
 
     void serialize(std::ostream &os, int16_t api_version) const;
 


### PR DESCRIPTION
- Added timeouts to `tcp_client` (and `kafka_connection`).
- Implemented handling of (prematurely) terminated TCP connections.
- Implemented "translation" of network exceptions into error codes (as Kafka already sends errors as error codes and there are a few of them specifically dedicated for network errors).