### PR TITLE
Add Connection Manager class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,6 +574,7 @@ add_library (seastar STATIC
   src/http/transformers.cc
   src/json/formatter.cc
   src/json/json_elements.cc
+  src/kafka/connection/connection_manager.cc
   src/kafka/connection/kafka_connection.cc
   src/kafka/connection/tcp_connection.hh
   src/kafka/connection/tcp_connection.cc
@@ -586,6 +587,7 @@ add_library (seastar STATIC
   src/kafka/protocol/produce_response.cc
   src/kafka/protocol/produce_request.cc
   src/kafka/producer/kafka_producer.cc
+  src/kafka/utils/partitioner.cc
   src/net/arp.cc
   src/net/config.cc
   src/net/dhcp.cc

--- a/demos/kafka_demo.cc
+++ b/demos/kafka_demo.cc
@@ -64,7 +64,7 @@ int main(int ac, char** av) {
                 fprint(std::cout, "Enter value: ");
                 std::cin >> value;
 
-                producer.produce(topic, key, value, 0).wait();
+                producer.produce(topic, key, value).wait();
             }
         });
     });

--- a/src/kafka/connection/connection_manager.cc
+++ b/src/kafka/connection/connection_manager.cc
@@ -1,0 +1,61 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2019 ScyllaDB Ltd.
+ */
+
+#include "connection_manager.hh"
+
+namespace seastar {
+
+namespace kafka {
+
+future<lw_shared_ptr<kafka_connection>> connection_manager::connect(const std::string& host, uint16_t port) {
+    auto conn = _connections.find({host, port});
+    return conn != _connections.end()
+        ? make_ready_future<lw_shared_ptr<kafka_connection>>(conn->second)
+        : kafka_connection::connect(host, port, _client_id, 500).then([this, host, port] (lw_shared_ptr<kafka_connection> conn) {
+            _connections.insert({{host, port}, conn});
+            return conn;
+    });
+}
+
+std::optional<lw_shared_ptr<kafka_connection>> connection_manager::get_connection(const connection_id& connection) {
+    auto conn = _connections.find(connection);
+    return conn != _connections.end() ? std::make_optional(conn->second) : std::nullopt;
+}
+
+future<> connection_manager::disconnect(const connection_id& connection) {
+    auto conn = _connections.find(connection);
+    if (conn != _connections.end()) {
+        return conn->second->close().then([this, conn] {
+            _connections.erase(conn);
+        });
+    }
+
+    return make_ready_future();
+}
+
+future<metadata_response> connection_manager::ask_for_metadata(const seastar::kafka::metadata_request &request) {
+    return _connections.begin()->second->send(request);
+}
+
+}
+
+}

--- a/src/kafka/connection/connection_manager.hh
+++ b/src/kafka/connection/connection_manager.hh
@@ -22,32 +22,38 @@
 
 #pragma once
 
-#include <string>
+#include "kafka_connection.hh"
+#include "../protocol/metadata_response.hh"
+#include "../protocol/metadata_request.hh"
 
+#include <boost/functional/hash.hpp>
 
-#include "../../../../src/kafka/connection/connection_manager.hh"
-#include "../../../../src/kafka/utils/partitioner.hh"
-
-#include <seastar/core/future.hh>
-#include <seastar/net/net.hh>
+#include <unordered_map>
 
 namespace seastar {
 
 namespace kafka {
 
-class kafka_producer {
+class connection_manager {
+public:
+
+    using connection_id = std::pair<std::string, uint16_t>;
+
 private:
 
+    std::unordered_map<connection_id, lw_shared_ptr<kafka_connection>, boost::hash<connection_id>> _connections;
     std::string _client_id;
-    connection_manager _connection_manager;
-    partitioner _partitioner;
-
-    seastar::future<metadata_response> refresh_metadata();
 
 public:
-    explicit kafka_producer(std::string client_id);
-    seastar::future<> init(std::string server_address, uint16_t port);
-    seastar::future<> produce(std::string topic_name, std::string key, std::string value);
+
+    explicit connection_manager(std::string client_id)
+        : _client_id(std::move(client_id)) {};
+
+    future<lw_shared_ptr<kafka_connection>> connect(const std::string& host, uint16_t port);
+    std::optional<lw_shared_ptr<kafka_connection>> get_connection(const connection_id& connection);
+    future<> disconnect(const connection_id& connection);
+
+    future<metadata_response> ask_for_metadata(const metadata_request& request);
 
 };
 

--- a/src/kafka/connection/kafka_connection.cc
+++ b/src/kafka/connection/kafka_connection.cc
@@ -46,6 +46,10 @@ future<> kafka_connection::init() {
             });
 }
 
+future<> kafka_connection::close() {
+    return _connection->close();
+}
+
 }
 
 }

--- a/src/kafka/connection/kafka_connection.hh
+++ b/src/kafka/connection/kafka_connection.hh
@@ -117,6 +117,8 @@ public:
         _client_id(std::move(client_id)),
         _correlation_id(0) {}
 
+    future<> close();
+
     template<typename RequestType>
     future<typename RequestType::response_type> send(const RequestType& request) {
         return send(request, _api_versions.max_version<RequestType>());

--- a/src/kafka/utils/partitioner.cc
+++ b/src/kafka/utils/partitioner.cc
@@ -20,36 +20,16 @@
  * Copyright (C) 2019 ScyllaDB Ltd.
  */
 
-#pragma once
-
-#include <string>
-
-
-#include "../../../../src/kafka/connection/connection_manager.hh"
-#include "../../../../src/kafka/utils/partitioner.hh"
-
-#include <seastar/core/future.hh>
-#include <seastar/net/net.hh>
+#include "partitioner.hh"
 
 namespace seastar {
 
 namespace kafka {
 
-class kafka_producer {
-private:
-
-    std::string _client_id;
-    connection_manager _connection_manager;
-    partitioner _partitioner;
-
-    seastar::future<metadata_response> refresh_metadata();
-
-public:
-    explicit kafka_producer(std::string client_id);
-    seastar::future<> init(std::string server_address, uint16_t port);
-    seastar::future<> produce(std::string topic_name, std::string key, std::string value);
-
-};
+metadata_response_partition partitioner::get_partition(const std::string &key, const kafka_array_t<metadata_response_partition> &partitions) const {
+    size_t index = std::rand() % partitions->size();
+    return partitions[index];
+}
 
 }
 

--- a/src/kafka/utils/partitioner.hh
+++ b/src/kafka/utils/partitioner.hh
@@ -22,32 +22,17 @@
 
 #pragma once
 
-#include <string>
-
-
-#include "../../../../src/kafka/connection/connection_manager.hh"
-#include "../../../../src/kafka/utils/partitioner.hh"
-
-#include <seastar/core/future.hh>
-#include <seastar/net/net.hh>
+#include "../protocol/metadata_response.hh"
 
 namespace seastar {
 
 namespace kafka {
 
-class kafka_producer {
-private:
-
-    std::string _client_id;
-    connection_manager _connection_manager;
-    partitioner _partitioner;
-
-    seastar::future<metadata_response> refresh_metadata();
+class partitioner {
 
 public:
-    explicit kafka_producer(std::string client_id);
-    seastar::future<> init(std::string server_address, uint16_t port);
-    seastar::future<> produce(std::string topic_name, std::string key, std::string value);
+
+    metadata_response_partition get_partition(const std::string &key, const kafka_array_t<metadata_response_partition> &partitions) const;
 
 };
 


### PR DESCRIPTION
This change adds a connection manager unit to keep track of open connections
and allow for a fast access by the producer. With that we can now manage
multiple brokers and read their addresses from metadata requests.
It also introduces a dummy partitioner for further development.

Connection Pool + Multibroker demo