### PR TITLE
kafka: Implement retry_helper

### DIFF
--- a/src/kafka/utils/retry_helper.hh
+++ b/src/kafka/utils/retry_helper.hh
@@ -1,0 +1,99 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2019 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cmath>
+#include <random>
+#include <chrono>
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/util/bool_class.hh>
+
+namespace seastar {
+
+namespace kafka {
+
+struct do_retry_tag { };
+using do_retry = bool_class<do_retry_tag>;
+
+class retry_helper {
+private:
+    uint32_t _max_retry_count;
+    float _base_ms;
+    uint32_t _max_backoff_ms;
+
+    std::random_device _rd;
+    std::mt19937 _mt;
+
+    template<typename AsyncAction, typename DataType>
+    future<> with_retry(DataType& data, AsyncAction&& action, uint32_t retry_number) {
+        if (retry_number >= _max_retry_count) {
+            return make_ready_future<>();
+        }
+        return backoff(retry_number)
+        .then([this, &data, action = std::forward<AsyncAction>(action), retry_number]() mutable {
+            return futurize_apply(action, data)
+            .then([this, &data, action = std::forward<AsyncAction>(action), retry_number](auto do_retry_val) mutable {
+                if (do_retry_val == do_retry::yes) {
+                    return with_retry(data, std::forward<AsyncAction>(action), retry_number + 1);
+                } else {
+                    return make_ready_future<>();
+                }
+            });
+        });
+    }
+
+    future<> backoff(uint32_t retry_number) {
+        if (retry_number == 0) {
+            return make_ready_future<>();
+        }
+
+        // Exponential backoff with (full) jitter
+        auto backoff_time = _base_ms * std::pow(2.0f, retry_number - 1);
+        auto backoff_time_discrete = static_cast<uint32_t>(std::round(backoff_time));
+
+        auto capped_backoff_time = std::min(_max_backoff_ms, backoff_time_discrete);
+        std::uniform_int_distribution<uint32_t> dist(0, capped_backoff_time);
+
+        auto jittered_backoff = dist(_mt);
+        return seastar::sleep(std::chrono::milliseconds(jittered_backoff));
+    }
+
+public:
+    retry_helper(uint32_t max_retry_count, float base_ms, uint32_t max_backoff_ms)
+        : _max_retry_count(max_retry_count), _base_ms(base_ms), _max_backoff_ms(max_backoff_ms), _mt(_rd()) {}
+
+    template<typename AsyncAction, typename DataType>
+    future<> with_retry(DataType&& data, AsyncAction&& action) {
+        return do_with(std::forward<DataType>(data),
+                [this, action = std::forward<AsyncAction>(action)](auto& data_ref) mutable {
+            return with_retry(data_ref, std::forward<AsyncAction>(action), 0);
+        });
+    }
+};
+
+}
+
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -319,6 +319,9 @@ seastar_add_test (kafka_protocol
   KIND BOOST
   SOURCES kafka_protocol_test.cc)
 
+seastar_add_test (kafka_retry_helper
+  SOURCES kafka_retry_helper_test.cc)
+
 seastar_add_test (lowres_clock
   SOURCES lowres_clock_test.cc)
 

--- a/tests/unit/kafka_retry_helper_test.cc
+++ b/tests/unit/kafka_retry_helper_test.cc
@@ -54,6 +54,16 @@ SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_capped_retries) {
     BOOST_REQUIRE_EQUAL(retry_count, 5);
 }
 
+SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_future) {
+    kafka::retry_helper helper(5, 1, 1000);
+    auto retry_count = 0;
+    helper.with_retry([&retry_count] {
+        retry_count++;
+        return make_ready_future<kafka::do_retry>(kafka::do_retry::yes);
+    }).wait();
+    BOOST_REQUIRE_EQUAL(retry_count, 5);
+}
+
 SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_modify_data) {
     kafka::retry_helper helper(5, 1, 1000);
     auto retry_count = 0;

--- a/tests/unit/kafka_retry_helper_test.cc
+++ b/tests/unit/kafka_retry_helper_test.cc
@@ -1,0 +1,74 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2019 ScyllaDB Ltd.
+ */
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/testing/test_runner.hh>
+#include <boost/test/included/unit_test.hpp>
+#include <vector>
+
+#include "../../src/kafka/utils/retry_helper.hh"
+
+using namespace seastar;
+
+SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_early_stop) {
+    kafka::retry_helper helper(5, 1, 1000);
+    auto retry_count = 0;
+    helper.with_retry(0, [&retry_count](auto& data) {
+        retry_count++;
+        data++;
+        if (data >= 3) {
+            return kafka::do_retry::no;
+        }
+        return kafka::do_retry::yes;
+    }).wait();
+    BOOST_REQUIRE_EQUAL(retry_count, 3);
+}
+
+SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_capped_retries) {
+    kafka::retry_helper helper(5, 1, 1000);
+    auto retry_count = 0;
+    helper.with_retry(0, [&retry_count](auto& data) {
+        retry_count++;
+        return kafka::do_retry::yes;
+    }).wait();
+    BOOST_REQUIRE_EQUAL(retry_count, 5);
+}
+
+SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_modify_data) {
+    kafka::retry_helper helper(5, 1, 1000);
+    auto retry_count = 0;
+    std::vector<int> retry_data;
+
+    helper.with_retry(std::vector<int>{1, 2, 3}, [&retry_count, &retry_data](auto& data) {
+        if (data.empty()) {
+            return kafka::do_retry::no;
+        }
+        retry_data.push_back(data.back());
+        data.pop_back();
+        retry_count++;
+        return kafka::do_retry::yes;
+    }).wait();
+
+    BOOST_REQUIRE_EQUAL(retry_count, 3);
+    std::vector<int> expected_data{3, 2, 1};
+    BOOST_TEST(retry_data == expected_data, boost::test_tools::per_element());
+}


### PR DESCRIPTION
Implement retry_helper: a future utility class which allows retries of futures. Retry count is capped and controlled by constructor argument. Retries are started after a backoff time, using exponential backoff with jitter strategy.

with_retry method strives to be a general solution for retry problems as it allows for modification of retry data between retries and manual control of whether the next retry is needed.

### Real life example (pseudocode)
Suppose we want to send 3 numbers. In case of error, we will get a response with information about failure of sending *some* of the 3 numbers. In such case we have to resend those failed numbers.
```cpp
helper.with_retry(std::vector<int>{1, 2, 3}, [](auto& data) {
    // data is a vector of numbers to send
    auto response = send(data);

    // If all numbers were sent correctly, there is no need for retry:
    if (response.succeeded()) {
        return kafka::do_retry::no;
    }

    // Otherwise, we modify data to only contain numbers which failed to send.
    // This modified data will be used in next retry.
    data = response.failed_numbers();

    // We can perform some additional actions:
    kafka.refresh_metadata();

    return kafka::do_retry::yes;
});
```