### PR TITLE
kafka: E2E tests

### DIFF
--- a/scripts/kafka_e2e_local/test_base_producer.sh
+++ b/scripts/kafka_e2e_local/test_base_producer.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+if [ -z ${KAFKA_DEMO_DIR+x} ]; then
+    tput setaf 1
+    echo "KAFKA_DEMO_DIR not set. Set environment variable KAFKA_DEMO_DIR to a directory of kafka_demo executable."
+    tput sgr0
+    exit 1
+fi
+
+if [ -z ${KAFKA_BIN_DIR+x} ]; then
+    tput setaf 1
+    echo "KAFKA_BIN_DIR not set. Set environment variable KAFKA_BIN_DIR to Kafka bin directory from Kafka sources,"
+    echo "which contains console consumer and other tools."
+    tput sgr0
+    exit 1
+fi
+
+function init_kafka() {
+    tput setaf 4
+    echo "Starting Kafka."
+    tput sgr0
+
+    cd ../kafkadev_local || exit
+
+    terraform init >/dev/null 2>&1
+    terraform apply --var "kafka_count=$1" --var "network_cidr=$2" --auto-approve >/dev/null 2>&1
+
+    cd "$OLDPWD"
+
+    # Wait 10s for Kafka to start up.
+    sleep 10s
+
+    tput setaf 3
+    printf "Started Kafka.\n\n"
+    tput sgr0
+}
+
+function init_topic() {
+    tput setaf 4
+    echo "Creating topic: $4."
+    tput sgr0
+
+    "$KAFKA_BIN_DIR"/kafka-topics.sh --create --bootstrap-server "$1" --replication-factor "$2" \
+        --partitions "$3" --topic "$4" >/dev/null 2>&1
+}
+
+function init_producer() {
+    # Wait 15s for topics to init their leaders, etc.
+    tput setaf 4
+    echo "Waiting 15s for Kafka start up to fully finish."
+    tput sgr0
+    sleep 15s
+
+    touch .kafka_producer_input
+
+    # Set up netcat at port 7777 to pipe input into.
+    (nc -k -l 7777 | "$KAFKA_DEMO_DIR"/kafka_demo --host "$1" >/dev/null 2>&1) &
+    KAFKA_DEMO_PID=$!
+
+    tput setaf 3
+    printf "Started producer.\n\n"
+    tput sgr0
+}
+
+function init_consumer() {
+    "$KAFKA_BIN_DIR"/kafka-console-consumer.sh --bootstrap-server "$1" \
+        --whitelist "$2" > .kafka_consumer_output 2>/dev/null &
+    KAFKA_CONSUMER_PID=$!
+
+    tput setaf 4
+    echo "Starting consumer. Waiting 10s for it to start up."
+    tput sgr0
+
+    # Wait for consumer (and producer) to start up.
+    # Mitigates against possible race conditions, Kafka leader not elected.
+    sleep 10s
+
+    tput setaf 3
+    printf "Started consumer.\n\n"
+    tput sgr0
+
+    tput setaf 11
+    echo "Starting test!"
+    tput sgr0
+}
+
+function write_random() {
+    RANDOM_LINE=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 30 ; echo '')
+    echo "$1" | nc localhost 7777
+    echo "$RANDOM_LINE" | nc localhost 7777
+    echo "$RANDOM_LINE" | nc localhost 7777
+    echo "$RANDOM_LINE" >> .kafka_producer_input
+}
+
+function invoke_docker() {
+    CONTAINERS=$(cd ../kafkadev_local; terraform output -json kafka_name | cut -c2- | rev | cut -c2- | rev | tr ',' '\n')
+    NTH=$(echo $CONTAINERS | tr ' ' '\n' |  sed -n "$1p" | tr -d '"')
+
+    tput setaf 4
+    echo "Invoking docker: docker $2 $NTH."
+    tput sgr0
+
+    docker $2 $NTH >/dev/null 2>&1
+}
+
+function end_test() {
+    tput setaf 11
+    echo "Ending test!"
+    tput sgr0
+
+    tput setaf 4
+    echo "Waiting 5s for processes to wind up."
+    tput sgr0
+
+    echo "q" | nc localhost 7777
+    sleep 5s
+
+    pkill -P $KAFKA_DEMO_PID >/dev/null 2>&1
+    pkill -P $KAFKA_CONSUMER_PID >/dev/null 2>&1
+
+    # Sort files, because partitions can change order of messages.
+    sort -o .kafka_consumer_output .kafka_consumer_output
+    sort -o .kafka_producer_input .kafka_producer_input
+
+    if cmp -s .kafka_consumer_output .kafka_producer_input; then
+        tput setaf 2
+        echo "TEST PASSED! Consumer has received all messages from producer."
+        tput sgr0
+    else
+        tput setaf 1
+        echo "TEST FAILED! Consumer has NOT received all messages from producer."
+        tput sgr0
+    fi
+
+    rm .kafka_producer_input
+    rm .kafka_consumer_output
+
+    cd ../kafkadev_local || exit
+
+    terraform destroy --var "kafka_count=$1" --var "network_cidr=$2" --auto-approve >/dev/null 2>&1
+
+    cd "$OLDPWD"
+}

--- a/scripts/kafka_e2e_local/test_producer1.sh
+++ b/scripts/kafka_e2e_local/test_producer1.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Producer test 1.
+# Create 1 broker cluster and a single topic.
+# Write a few messages to this topic.
+
+source "./test_base_producer.sh"
+
+init_kafka "1" "172.14.0.0/16"
+init_topic "172.14.0.1:9092" "1" "1" "single"
+init_producer "172.14.0.1"
+init_consumer "172.14.0.1:9092" "single"
+
+write_random "single"
+write_random "single"
+write_random "single"
+end_test "1" "172.14.0.0/16"

--- a/scripts/kafka_e2e_local/test_producer2.sh
+++ b/scripts/kafka_e2e_local/test_producer2.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Producer test 2.
+# Create 3 broker cluster and two topics with 3 partitions.
+# Write a few messages to both topics.
+
+source "./test_base_producer.sh"
+
+init_kafka "3" "172.14.0.0/16"
+init_topic "172.14.0.1:9092" "3" "3" "triple"
+init_topic "172.14.0.1:9092" "3" "3" "triple2"
+init_producer "172.14.0.1"
+init_consumer "172.14.0.1:9092" "triple|triple2"
+
+write_random "triple"
+write_random "triple"
+write_random "triple"
+write_random "triple2"
+end_test "3" "172.14.0.0/16"

--- a/scripts/kafka_e2e_local/test_producer3.sh
+++ b/scripts/kafka_e2e_local/test_producer3.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Producer test 3.
+# Create 3 broker cluster and two topics with 3 partitions.
+# Write 200 messages total to both topics.
+
+source "./test_base_producer.sh"
+
+init_kafka "3" "172.14.0.0/16"
+init_topic "172.14.0.1:9092" "3" "3" "triple"
+init_topic "172.14.0.1:9092" "3" "3" "triple2"
+init_producer "172.14.0.1"
+init_consumer "172.14.0.1:9092" "triple|triple2"
+
+for i in {1..100}; do
+    write_random "triple"
+    write_random "triple2"
+done
+
+end_test "3" "172.14.0.0/16"

--- a/scripts/kafka_e2e_local/test_producer4.sh
+++ b/scripts/kafka_e2e_local/test_producer4.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Producer test 4.
+# Create 3 broker cluster and two topics with 3 partitions.
+# Write a few messages to both topics.
+# Stop second broker.
+# Write a few messages to both topics.
+# Start second broker.
+
+source "./test_base_producer.sh"
+
+init_kafka "3" "172.14.0.0/16"
+init_topic "172.14.0.1:9092" "3" "3" "triple"
+init_topic "172.14.0.1:9092" "3" "3" "triple2"
+init_producer "172.14.0.1"
+init_consumer "172.14.0.1:9092" "triple|triple2"
+
+for i in {1..10}; do
+    write_random "triple"
+    write_random "triple2"
+done
+
+sleep 5s
+invoke_docker "2" "stop"
+sleep 10s
+
+for i in {1..10}; do
+    write_random "triple"
+    write_random "triple2"
+done
+
+sleep 5s
+invoke_docker "2" "start"
+sleep 10s
+
+end_test "3" "172.14.0.0/16"

--- a/scripts/kafka_e2e_local/test_producer5.sh
+++ b/scripts/kafka_e2e_local/test_producer5.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Producer test 5.
+# Create 3 broker cluster and two topics with 3 partitions.
+# Write a few messages to both topics.
+# Stop first broker.
+# Write a few messages to both topics.
+# Start first broker.
+
+source "./test_base_producer.sh"
+
+init_kafka "3" "172.14.0.0/16"
+init_topic "172.14.0.1:9092" "3" "3" "triple"
+init_topic "172.14.0.1:9092" "3" "3" "triple2"
+init_producer "172.14.0.1"
+init_consumer "172.14.0.1:9092" "triple|triple2"
+
+for i in {1..10}; do
+    write_random "triple"
+    write_random "triple2"
+done
+
+sleep 5s
+invoke_docker "1" "stop"
+sleep 10s
+
+for i in {1..10}; do
+    write_random "triple"
+    write_random "triple2"
+done
+
+sleep 5s
+invoke_docker "1" "start"
+sleep 10s
+
+end_test "3" "172.14.0.0/16"


### PR DESCRIPTION
Implement end-to-end tests for Kafka producer.

Tests (based on `test_base_producer.sh`) start a new Kafka cluster, create topics, write random data using our producer and validate using official Kafka console consumer.

Tests number 4 and 5 check the producer when one of the broker is turned off. Test number 5 currently fails (tries to read metadata from turned off Kafka broker).

### How to launch tests? 
```bash 
$ # Directory with executable of Kafka demo
$ export KAFKA_DEMO_DIR=/home/piotrgrabowski/mnt/seastar/cmake-build-debug/demos
$ # bin directory of extracted Kafka source (https://www.apache.org/dyn/closer.cgi?path=/kafka/2.4.0/kafka-2.4.0-src.tgz)
$ export KAFKA_BIN_DIR=/home/piotrgrabowski/Pobrane/kafka_2.12-2.3.0/bin
$ ./test_producer1.sh
```