### PR TITLE
Add producer properties as a way for the kafka producer to be customizable by the user.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,6 +594,7 @@ add_library (seastar STATIC
   src/kafka/producer/kafka_producer.cc
   src/kafka/producer/sender.cc
   src/kafka/utils/partitioner.cc
+  src/kafka/utils/defaults.cc
   src/net/arp.cc
   src/net/config.cc
   src/net/dhcp.cc

--- a/demos/kafka_demo.cc
+++ b/demos/kafka_demo.cc
@@ -42,9 +42,14 @@ int main(int ac, char** av) {
             uint16_t port = config["port"].as<uint16_t>();
             (void) port;
 
-            kafka::kafka_producer producer("seastar-kafka-demo");
-            fprint(std::cout, "Producer built\n\n");
-            producer.init(host, port).wait();
+            kafka::producer_properties properties;
+            properties._client_id = "seastar-kafka-demo";
+            properties._servers = {
+                    {host, port}
+            };
+
+            kafka::kafka_producer producer(std::move(properties));
+            producer.init().wait();
             fprint(std::cout, "Producer initialized and ready to send\n\n");
 
             std::string topic, key, value;

--- a/include/seastar/kafka/producer/kafka_producer.hh
+++ b/include/seastar/kafka/producer/kafka_producer.hh
@@ -31,6 +31,7 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/net/net.hh>
+#include <seastar/kafka/producer/producer_properties.hh>
 
 namespace seastar {
 
@@ -39,15 +40,14 @@ namespace kafka {
 class kafka_producer {
 private:
 
-    std::string _client_id;
+    producer_properties _properties;
     lw_shared_ptr<connection_manager> _connection_manager;
-    std::unique_ptr<partitioner> _partitioner;
     lw_shared_ptr<metadata_manager> _metadata_manager;
     batcher _batcher;
 
 public:
-    explicit kafka_producer(std::string client_id);
-    seastar::future<> init(std::string server_address, uint16_t port);
+    explicit kafka_producer(producer_properties&& properties);
+    seastar::future<> init();
     seastar::future<> produce(std::string topic_name, std::string key, std::string value);
     seastar::future<> flush();
     seastar::future<> disconnect();

--- a/include/seastar/kafka/producer/producer_properties.hh
+++ b/include/seastar/kafka/producer/producer_properties.hh
@@ -1,0 +1,75 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2019 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include <functional>
+
+#include "../../../../src/kafka/utils/partitioner.hh"
+
+#include <seastar/util/bool_class.hh>
+#include <seastar/kafka/utils/defaults.hh>
+
+namespace seastar {
+
+namespace kafka {
+
+enum class ack_policy {
+    NONE = 0,
+    LEADER = 1,
+    ALL = -1,
+};
+
+struct enable_idempotence_tag {};
+using enable_idempotence = bool_class<enable_idempotence_tag>;
+
+class producer_properties {
+
+public:
+
+    ack_policy _acks = ack_policy::LEADER;
+    enable_idempotence _enable_idempotence = enable_idempotence::no;
+
+    uint16_t _linger = 0;
+    uint16_t _request_size = 50000;
+    uint16_t _max_in_flight = 5;
+
+    uint32_t _buffer_memory = 33554432;
+    uint32_t _retries = 10;
+    uint32_t _batch_size = 16384;
+    uint32_t _request_timeout = 500;
+    uint32_t _metadata_refresh = 300000;
+
+    std::string _client_id {};
+    std::string _transactional_id {};
+    std::vector<std::pair<std::string, uint16_t>> _servers {};
+
+    std::unique_ptr<partitioner> _partitioner = defaults::round_robin_partitioner();
+    std::function<future<>(uint32_t)> _retry_backoff_strategy = defaults::exp_retry_backoff(20, 1000);
+
+};
+
+}
+
+}

--- a/include/seastar/kafka/utils/defaults.hh
+++ b/include/seastar/kafka/utils/defaults.hh
@@ -22,33 +22,25 @@
 
 #pragma once
 
-#include <utility>
-#include <vector>
+#include <functional>
+#include <memory>
 
-#include "sender.hh"
-#include "../utils/retry_helper.hh"
+#include "../../../../src/kafka/utils/partitioner.hh"
+
+#include <seastar/core/future.hh>
 
 namespace seastar {
 
 namespace kafka {
 
-class batcher {
-private:
-    std::vector<sender_message> _messages;
-    lw_shared_ptr<metadata_manager> _metadata_manager;
-    lw_shared_ptr<connection_manager> _connection_manager;
-    retry_helper _retry_helper;
-public:
-    batcher(lw_shared_ptr<metadata_manager> metadata_manager,
-            lw_shared_ptr<connection_manager> connection_manager,
-            uint32_t max_retries, const std::function<future<>(uint32_t)> &retry_strategy)
-            : _metadata_manager(std::move(metadata_manager)),
-            _connection_manager(std::move(connection_manager)),
-            _retry_helper(max_retries, retry_strategy) {}
+namespace defaults {
 
-    void queue_message(sender_message message);
-    future<> flush(uint32_t connection_timeout);
-};
+std::function<future<>(uint32_t)> exp_retry_backoff(uint32_t base_ms, uint32_t max_backoff_ms);
+
+std::unique_ptr<partitioner> round_robin_partitioner();
+std::unique_ptr<partitioner> random_partitioner();
+
+}
 
 }
 

--- a/src/kafka/connection/connection_manager.cc
+++ b/src/kafka/connection/connection_manager.cc
@@ -27,12 +27,12 @@ namespace seastar {
 
 namespace kafka {
 
-future<lw_shared_ptr<kafka_connection>> connection_manager::connect(const std::string& host, uint16_t port) {
-    return with_semaphore(_connect_semaphore, 1, [this, host, port] {
+future<lw_shared_ptr<kafka_connection>> connection_manager::connect(const std::string& host, uint16_t port, uint32_t timeout) {
+    return with_semaphore(_connect_semaphore, 1, [this, host, port, timeout] {
         auto conn = _connections.find({host, port});
         return conn != _connections.end()
                ? make_ready_future<lw_shared_ptr<kafka_connection>>(conn->second)
-               : kafka_connection::connect(host, port, _client_id, 500)
+               : kafka_connection::connect(host, port, _client_id, timeout)
                .then([this, host, port] (lw_shared_ptr<kafka_connection> conn) {
                     _connections.insert({{host, port}, conn});
                     return conn;

--- a/src/kafka/connection/connection_manager.hh
+++ b/src/kafka/connection/connection_manager.hh
@@ -59,12 +59,12 @@ public:
         _connect_semaphore(1),
         _send_semaphore(1) {}
 
-    future<lw_shared_ptr<kafka_connection>> connect(const std::string& host, uint16_t port);
+    future<lw_shared_ptr<kafka_connection>> connect(const std::string& host, uint16_t port, uint32_t timeout);
     std::optional<lw_shared_ptr<kafka_connection>> get_connection(const connection_id& connection);
     future<> disconnect(const connection_id& connection);
 
     template<typename RequestType>
-    future<typename RequestType::response_type> send(RequestType request, const std::string& host, uint16_t port) {
+    future<typename RequestType::response_type> send(RequestType request, const std::string& host, uint16_t port, uint32_t timeout) {
         // In order to preserve ordering of sends, a semaphore with
         // count = 1 is used due to its FIFO guarantees.
         //
@@ -82,8 +82,8 @@ public:
         // returned as future<future<response>> and "unpacked"
         // outside the semaphore - scheduling inside semaphore
         // (only 1 at the time) and waiting for result outside it.
-        return with_semaphore(_send_semaphore, 1, [this, request = std::move(request), host, port] {
-            return connect(host, port).then([request = std::move(request)](auto conn) {
+        return with_semaphore(_send_semaphore, 1, [this, request = std::move(request), host, port, timeout] {
+            return connect(host, port, timeout).then([request = std::move(request)](auto conn) {
                 auto send_future = conn->send(std::move(request)).finally([conn]{});
                 return make_ready_future<decltype(send_future)>(std::move(send_future));
             });

--- a/src/kafka/connection/tcp_connection.hh
+++ b/src/kafka/connection/tcp_connection.hh
@@ -33,7 +33,7 @@ namespace kafka {
 
 struct tcp_connection_exception : public std::runtime_error {
 public:
-    tcp_connection_exception(const std::string& message) : runtime_error(message) {}
+    explicit tcp_connection_exception(const std::string& message) : runtime_error(message) {}
 };
 
 class tcp_connection {

--- a/src/kafka/producer/batcher.cc
+++ b/src/kafka/producer/batcher.cc
@@ -30,8 +30,8 @@ void batcher::queue_message(sender_message message) {
     _messages.emplace_back(std::move(message));
 }
 
-future<> batcher::flush() {
-    return do_with(sender(_connection_manager, _metadata_manager), [this](sender& sender) {
+future<> batcher::flush(uint32_t connection_timeout) {
+    return do_with(sender(_connection_manager, _metadata_manager, connection_timeout), [this](sender& sender) {
         bool is_batch_loaded = false;
         return _retry_helper.with_retry([this, &sender, is_batch_loaded]() mutable {
             // It is important to move messages from current batch

--- a/src/kafka/producer/sender.hh
+++ b/src/kafka/producer/sender.hh
@@ -72,6 +72,8 @@ private:
     std::map<topic_partition, std::vector<sender_message*>> _messages_split_by_topic_partition;
     std::vector<future<std::pair<connection_id, produce_response>>> _responses;
 
+    uint32_t _connection_timeout;
+
     std::optional<connection_id> broker_for_topic_partition(const std::string& topic, int32_t partition_index);
     connection_id broker_for_id(int32_t id);
 
@@ -88,7 +90,7 @@ private:
     future<> process_messages_errors();
     
 public:
-    sender(lw_shared_ptr<connection_manager> connection_manager, lw_shared_ptr<metadata_manager> metadata_manager);
+    sender(lw_shared_ptr<connection_manager> connection_manager, lw_shared_ptr<metadata_manager> metadata_manager, uint32_t connection_timeout);
 
     void move_messages(std::vector<sender_message>& messages);
     size_t messages_size() const;

--- a/src/kafka/utils/defaults.cc
+++ b/src/kafka/utils/defaults.cc
@@ -1,0 +1,67 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2019 ScyllaDB Ltd.
+ */
+
+#include <cmath>
+#include <random>
+#include <chrono>
+
+#include <seastar/kafka/utils/defaults.hh>
+#include <seastar/core/sleep.hh>
+
+namespace seastar {
+
+namespace kafka {
+
+namespace defaults {
+
+std::function<future<>(uint32_t)> exp_retry_backoff(uint32_t base_ms, uint32_t max_backoff_ms) {
+    std::random_device rd;
+    return [base_ms, max_backoff_ms, mt = std::mt19937(rd())] (uint32_t retry_number) mutable {
+        if (retry_number == 0) {
+            return make_ready_future<>();
+        }
+
+        // Exponential backoff with (full) jitter
+        auto backoff_time = base_ms * std::pow(2.0f, retry_number - 1);
+        auto backoff_time_discrete = static_cast<uint32_t>(std::round(backoff_time));
+
+        auto capped_backoff_time = std::min(max_backoff_ms, backoff_time_discrete);
+        std::uniform_int_distribution<uint32_t> dist(0, capped_backoff_time);
+
+        auto jittered_backoff = dist(mt);
+        return seastar::sleep(std::chrono::milliseconds(jittered_backoff));
+    };
+}
+
+std::unique_ptr<partitioner> round_robin_partitioner() {
+    return std::make_unique<rr_partitioner>();
+}
+
+std::unique_ptr<partitioner> random_partitioner() {
+    return std::make_unique<basic_partitioner>();
+}
+
+}
+
+}
+
+}

--- a/src/kafka/utils/partitioner.cc
+++ b/src/kafka/utils/partitioner.cc
@@ -33,7 +33,7 @@ metadata_response_partition basic_partitioner::get_partition(const std::string &
 }
 
 metadata_response_partition rr_partitioner::get_partition(const std::string &key, const kafka_array_t<metadata_response_partition> &partitions) {
-    if(key.size() > 0) {
+    if(!key.empty()) {
         boost::hash<std::string> key_hash;
         std::size_t h = key_hash(key);
         return partitions[h % partitions->size()];

--- a/src/kafka/utils/partitioner.hh
+++ b/src/kafka/utils/partitioner.hh
@@ -39,14 +39,14 @@ public:
 
 class basic_partitioner : public partitioner {
 public:
-    virtual metadata_response_partition get_partition(const std::string &key, const kafka_array_t<metadata_response_partition> &partitions);
+    metadata_response_partition get_partition(const std::string &key, const kafka_array_t<metadata_response_partition> &partitions) override;
 };
 
 class rr_partitioner : public partitioner {
 public:
-    virtual metadata_response_partition get_partition(const std::string &key, const kafka_array_t<metadata_response_partition> &partitions);
+    metadata_response_partition get_partition(const std::string &key, const kafka_array_t<metadata_response_partition> &partitions) override;
 private:
-    uint32_t counter;
+    uint32_t counter = 0;
 };
 
 }

--- a/src/kafka/utils/retry_helper.hh
+++ b/src/kafka/utils/retry_helper.hh
@@ -23,12 +23,9 @@
 #pragma once
 
 #include <cstdint>
-#include <cmath>
-#include <random>
-#include <chrono>
+#include <functional>
 
 #include <seastar/core/future.hh>
-#include <seastar/core/sleep.hh>
 #include <seastar/util/bool_class.hh>
 
 namespace seastar {
@@ -41,18 +38,15 @@ using do_retry = bool_class<do_retry_tag>;
 class retry_helper {
 private:
     uint32_t _max_retry_count;
-    float _base_ms;
-    uint32_t _max_backoff_ms;
 
-    std::random_device _rd;
-    std::mt19937 _mt;
+    std::function<future<>(uint32_t)> _backoff;
 
     template<typename AsyncAction>
     future<> with_retry(AsyncAction&& action, uint32_t retry_number) {
         if (retry_number >= _max_retry_count) {
             return make_ready_future<>();
         }
-        return backoff(retry_number)
+        return _backoff(retry_number)
         .then([this, action = std::forward<AsyncAction>(action), retry_number]() mutable {
             return futurize_apply(action)
             .then([this, action = std::forward<AsyncAction>(action), retry_number](auto do_retry_val) mutable {
@@ -65,25 +59,9 @@ private:
         });
     }
 
-    future<> backoff(uint32_t retry_number) {
-        if (retry_number == 0) {
-            return make_ready_future<>();
-        }
-
-        // Exponential backoff with (full) jitter
-        auto backoff_time = _base_ms * std::pow(2.0f, retry_number - 1);
-        auto backoff_time_discrete = static_cast<uint32_t>(std::round(backoff_time));
-
-        auto capped_backoff_time = std::min(_max_backoff_ms, backoff_time_discrete);
-        std::uniform_int_distribution<uint32_t> dist(0, capped_backoff_time);
-
-        auto jittered_backoff = dist(_mt);
-        return seastar::sleep(std::chrono::milliseconds(jittered_backoff));
-    }
-
 public:
-    retry_helper(uint32_t max_retry_count, float base_ms, uint32_t max_backoff_ms)
-        : _max_retry_count(max_retry_count), _base_ms(base_ms), _max_backoff_ms(max_backoff_ms), _mt(_rd()) {}
+    retry_helper(uint32_t max_retry_count, std::function<future<>(uint32_t)> backoff)
+        : _max_retry_count(max_retry_count), _backoff(std::move(backoff)) {}
 
     template<typename AsyncAction>
     future<> with_retry(AsyncAction&& action) {

--- a/tests/unit/kafka_retry_helper_test.cc
+++ b/tests/unit/kafka_retry_helper_test.cc
@@ -22,6 +22,7 @@
 
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>
+#include <seastar/kafka/utils/defaults.hh>
 #include <boost/test/included/unit_test.hpp>
 #include <vector>
 
@@ -30,7 +31,7 @@
 using namespace seastar;
 
 SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_early_stop) {
-    kafka::retry_helper helper(5, 1, 1000);
+    kafka::retry_helper helper(5, kafka::defaults::exp_retry_backoff(1, 1000));
     auto retry_count = 0;
     auto data = 0;
     helper.with_retry([&retry_count, data]() mutable {
@@ -45,7 +46,7 @@ SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_early_stop) {
 }
 
 SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_capped_retries) {
-    kafka::retry_helper helper(5, 1, 1000);
+    kafka::retry_helper helper(5, kafka::defaults::exp_retry_backoff(1, 1000));
     auto retry_count = 0;
     helper.with_retry([&retry_count] {
         retry_count++;
@@ -55,7 +56,7 @@ SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_capped_retries) {
 }
 
 SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_future) {
-    kafka::retry_helper helper(5, 1, 1000);
+    kafka::retry_helper helper(5, kafka::defaults::exp_retry_backoff(1, 1000));
     auto retry_count = 0;
     helper.with_retry([&retry_count] {
         retry_count++;
@@ -65,7 +66,7 @@ SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_future) {
 }
 
 SEASTAR_THREAD_TEST_CASE(kafka_retry_helper_test_modify_data) {
-    kafka::retry_helper helper(5, 1, 1000);
+    kafka::retry_helper helper(5, kafka::defaults::exp_retry_backoff(1, 1000));
     auto retry_count = 0;
     std::vector<int> data{1, 2, 3};
     std::vector<int> retry_data;


### PR DESCRIPTION
This change ties together various producer parameters into
a single properties object, easily customizable by the user.
Among the fields are parameters such as timeouts, backoff
strategies and partitioners as well as some that might be
introduced in the future (like acks)